### PR TITLE
Index version number

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,10 @@
         "panel.border": "#af9075",
         "sideBar.border": "#af9075",
         "editorGroup.border": "#af9075",
-        "tab.activeBorder": "#af9075"
+        "tab.activeBorder": "#af9075",
+        "sash.hoverBorder": "#af9075",
+        "statusBarItem.remoteBackground": "#997658",
+        "statusBarItem.remoteForeground": "#e7e7e7"
     },
     "peacock.color": "#997658"
 }

--- a/spec/ParseSpec.ts
+++ b/spec/ParseSpec.ts
@@ -24,6 +24,7 @@ describe('Parsing of versioned docs', () => {
     expect(result.href).not.to.be.undefined
     expect(result.name).not.to.be.undefined
     expect(result.text).not.to.be.undefined
+    expect(result.version).to.equal('0.0.1')
   })
 
   it('should have an href with structure: /component/version/page.html', () => {
@@ -55,6 +56,7 @@ describe('Parsing of NON versioned docs', () => {
     expect(result.href).not.to.be.undefined
     expect(result.name).not.to.be.undefined
     expect(result.text).not.to.be.undefined
+    expect(result.version).to.equal('')
   })
 
   it('should have an href with structure: /component/page.html', () => {

--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -13,6 +13,7 @@ export function buildFileList(documents: ParsedFileEntry[]): FileList {
           name: doc.name,
           href: doc.href,
           excerpt: doc.excerpt,
+          version: doc.version
       }
       fileList[doc.href] = entry
   })
@@ -28,6 +29,7 @@ export function buildLunrIndex(documents: ParsedFileEntry[]): lunr.Index {
       this.ref('href')
       this.field('name')
       this.field('text')
+      this.field('version')
 
       documents.forEach((doc: ParsedFileEntry) => {
           this.add(doc)

--- a/src/lib/files_map_entry.ts
+++ b/src/lib/files_map_entry.ts
@@ -4,7 +4,8 @@
 export interface FilesMapEntry {
   name: string,
   href: string,
-  excerpt: string
+  excerpt: string,
+  version: string
 }
 
 export type FileList = { [href: string]: FilesMapEntry }

--- a/src/lib/parsed_file_entry.ts
+++ b/src/lib/parsed_file_entry.ts
@@ -6,5 +6,6 @@ export interface ParsedFileEntry {
 	name: string,
 	text: string,
 	href: string,
-	excerpt: string
+	excerpt: string,
+	version: string
 }

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -166,6 +166,7 @@ export function parseAntoraFile(startPath: string): ParsedFileEntry[] {
 				text: text,
 				href: href,
 				excerpt: excerpt,
+				version: version
 			}
 			lunrIndex.push(obj)
 		})


### PR DESCRIPTION
This PR enables the indexer to expose the version number of the list of files being indexed, and to index entries based on it. This information is later delivered by the `embedded-search-engine` with search results.